### PR TITLE
qsub 1.0.2: Various fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qsub
 Title: Running Commands Remotely on 'Gridengine' Clusters
-Version: 1.0.1.9001
+Version: 1.0.2.9001
 Authors@R: c(
     person(
       "Robrecht", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qsub
 Title: Running Commands Remotely on 'Gridengine' Clusters
-Version: 1.0.1.9000
+Version: 1.0.1.9001
 Authors@R: c(
     person(
       "Robrecht", 
@@ -8,6 +8,13 @@ Authors@R: c(
       email = "rcannood@gmail.com", 
       role = c("aut", "cre"),
       comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")
+    ),
+    person(
+      "Wouter", 
+      "Saelens", 
+      email = "wouter.saelens@ugent.be", 
+      role = c("aut"), 
+      comment = c(ORCID = "0000-0002-7114-6248", github = "zouter")
     )
   )
 Description: Run 'lapply' calls in parallel by submitting them to 'gridengine' clusters using 'qsub'.

--- a/R/qacct.R
+++ b/R/qacct.R
@@ -24,7 +24,14 @@ qacct <- function(qsub_config) {
 #'
 #' @export
 qacct_remote <- function(remote, job_id) {
-  out <- run_remote(paste0("qacct -j ", job_id), remote)$stdout
+  out <- run_remote(command = "qacct", args = c("-j", job_id), remote = remote)
+
+  if (out$stderr != "") {
+    stop(out$stderr)
+  }
+
+  out <- out$stdout
+
   if (str_detect(out, "job id \\d* not found")[[1]]) {
     NULL
   } else {

--- a/R/qstat_j.R
+++ b/R/qstat_j.R
@@ -24,7 +24,13 @@ qstat_j <- function(qsub_config) {
 #'
 #' @export
 qstat_j_remote <- function(remote, job_id) {
-  out <- run_remote(paste0("qstat -j ", job_id), remote)$stdout
+  out <- run_remote(command = "qstat", args = c("-j", job_id), remote = remote)
+
+  if (out$stderr != "") {
+    stop(out$stderr)
+  }
+
+  out <- out$stdout
 
   if (str_detect(out, "Following jobs do not exist:")[[1]]) {
     NULL

--- a/R/ssh.R
+++ b/R/ssh.R
@@ -22,17 +22,17 @@ fetch_hostname_from_config <- function(host) {
 
       rel_config <- ssh_config[seq(hostname_match + 1, end - 1)]
 
-      rel_hostname <- rel_config %>% keep(~ str_detect("^ *HostName "))
+      rel_hostname <- rel_config %>% keep(~ str_detect(., "^ *HostName "))
       if (length(rel_hostname) == 1) {
         hostname <- rel_hostname %>% str_replace_all("^ *HostName *([^ ]*).*$", "\\1")
       }
 
-      rel_username <- rel_config %>% keep(~ str_detect("^ *User "))
+      rel_username <- rel_config %>% keep(~ str_detect(., "^ *User "))
       if (length(rel_hostname) == 1) {
         username <- rel_username %>% str_replace_all("^ *User *([^ ]*).*$", "\\1")
       }
 
-      rel_port <- rel_config %>% keep(~ str_detect("^ *Port "))
+      rel_port <- rel_config %>% keep(~ str_detect(., "^ *Port "))
       if (length(rel_hostname) == 1) {
         port <- rel_port %>% str_replace_all("^ *Port *([^ ]*).*$", "\\1")
       }

--- a/R/ssh.R
+++ b/R/ssh.R
@@ -94,7 +94,7 @@ create_ssh_connection <- function(remote) {
 #'
 #' @export
 run_remote <- function(command, remote, args = character(), verbose = FALSE, shell = FALSE) {
-  if (verbose) cat("# ", gsub("\n", "\n# ", cmd), "\n", sep="")
+  if (verbose) cat("# ", gsub("\n", "\n# ", cmd), "\n", sep = "")
 
   time1 <- Sys.time()
 

--- a/man/cat_remote.Rd
+++ b/man/cat_remote.Rd
@@ -4,7 +4,7 @@
 \alias{cat_remote}
 \title{Read from a file remotely}
 \usage{
-cat_remote(path, remote = NULL, verbose = FALSE)
+cat_remote(path, remote = "", verbose = FALSE)
 }
 \arguments{
 \item{path}{Path of the file.}

--- a/man/run_remote.Rd
+++ b/man/run_remote.Rd
@@ -4,16 +4,21 @@
 \alias{run_remote}
 \title{\code{run_remote} - Runs the command locally or remotely using ssh.}
 \usage{
-run_remote(cmd, remote, verbose = FALSE)
+run_remote(command, remote, args = character(), verbose = FALSE,
+  shell = FALSE)
 }
 \arguments{
-\item{cmd}{Command to run. If run locally, quotes should be escaped once.
+\item{command}{Command to run. If run locally, quotes should be escaped once.
 If run remotely, quotes should be escaped twice.}
 
 \item{remote}{Remote machine specification for ssh, in format such as \code{user@server} that does not
 require interactive password entry. For local execution, pass an empty string "" (default).}
 
+\item{args}{Character vector, arguments to the command.}
+
 \item{verbose}{If \code{TRUE} prints the command.}
+
+\item{shell}{Whether to execute the command in a shell}
 }
 \value{
 A list with components:

--- a/man/write_remote.Rd
+++ b/man/write_remote.Rd
@@ -4,7 +4,7 @@
 \alias{write_remote}
 \title{Write to a file remotely}
 \usage{
-write_remote(x, path, remote, verbose = FALSE)
+write_remote(x, path, remote = "", verbose = FALSE)
 }
 \arguments{
 \item{x}{The text to write to the file.}


### PR DESCRIPTION
* Fix `fetch_hostname_from_config`
* `run_remote`: arguments need to be passed seperately as a character vector.
* Fix `rsync_remote` on unix systems
* Updated for new `run_remote`: `cat_remote`, `ls_remote`, `qstat_remote` and `qacct_j_remote`