### PR TITLE
move 'execute_before' before loading the module

### DIFF
--- a/R/qsub_run.R
+++ b/R/qsub_run.R
@@ -224,9 +224,9 @@ setup_execution <- function(
     "#$ -l h_vmem=", qs$memory, "\n",
     ifelse(!is.null(qs$max_wall_time), paste0("#$ -l h_rt=", qs$max_wall_time, "\n"), ""),
     "cd ", qs$remote_dir, "\n",
+    paste0(paste0(qs$execute_before, collapse = "\n"), "\n"),
     "module unload R\n",
     ifelse(!is.null(qs$modules), paste0("module load ", qs$modules, "\n", collapse = "\n"), ""),
-    paste0(paste0(qs$execute_before, collapse = "\n"), "\n"),
     "Rscript --default-packages=methods,stats,utils,graphics,grDevices script.R $SGE_TASK_ID\n"
   )
   readr::write_lines(sh_script, qs$src_shfile)


### PR DESCRIPTION
Allows running on HPC clusters which need sourcing a script (or running a command) before loading the TCL module. University of Edinburgh's Eddie is an example.